### PR TITLE
Fix for #253

### DIFF
--- a/src/mainWindow/components/generic/Context.vue
+++ b/src/mainWindow/components/generic/Context.vue
@@ -76,4 +76,5 @@ export default class Context extends Vue {
   ul li
     &:hover
       background: var(--accent)
+      color: var(--textInverse)
 </style>

--- a/src/mainWindow/components/generic/Context.vue
+++ b/src/mainWindow/components/generic/Context.vue
@@ -76,5 +76,5 @@ export default class Context extends Vue {
   ul li
     &:hover
       background: var(--accent)
-      color: var(--textInverse)
+      color: var(--textInverse) !important
 </style>

--- a/src/preferenceWindow/components/pages/Themes.vue
+++ b/src/preferenceWindow/components/pages/Themes.vue
@@ -298,6 +298,7 @@ export default class Themes extends Vue {
   ul li
     &:hover
       background: var(--accent)
+      color: var(--textInverse) !important
 </style>
 
 <style lang="sass" scoped>


### PR DESCRIPTION
Everything is described in the Issue #253 so please for more information, head there.
TL;DR, right-click context menu had element on hover set color as such, it was in most cases unreadable (since most themes have accent color light/dark the same like their primary text, not inverted).

P.S. Sorry for two commits, found that the main app window has this set on different place and had the same issue :)