### PR TITLE
Fix environment specific junk

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,11 +5,8 @@
   "bazel.lsp.command": "bazel-lsp",
   "testing.coverageToolbarEnabled": true,
   "bazel.buildifierFixOnFormat": true,
-  "rust-analyzer.check.extraEnv": {
-    "ANDROID_NDK_HOME": "/home/ovenoboyo/Android/Sdk/ndk/30.0.14904198",
-    "ANDROID_HOME": "/home/ovenoboyo/Android/Sdk",
-    "ANDROID_SDK_ROOT": "/home/ovenoboyo/Android/Sdk"
-  },
+  // Android SDK/NDK env vars are inherited from the user's shell via .bazelrc
+  // (--repo_env=ANDROID_HOME, --repo_env=ANDROID_NDK_HOME). Do not override here.
   "rust-analyzer.check.overrideCommand": [
     "bazel",
     "--output_base=/tmp/bazel/ra_output",

--- a/android/local.properties
+++ b/android/local.properties
@@ -1,8 +1,0 @@
-## This file must *NOT* be checked into Version Control Systems,
-# as it contains information specific to your local configuration.
-#
-# Location of the SDK. This is only used by Gradle.
-# For customization when using a Version Control System, please read the
-# header note.
-#Tue May 26 01:19:35 PDT 2026
-sdk.dir=/home/ovenoboyo/Android/Sdk

--- a/core/state_manager/src/lib.rs
+++ b/core/state_manager/src/lib.rs
@@ -161,8 +161,13 @@ impl StateManager {
             let mut file_scanner = scanner.write().await;
             file_scanner.set_artist_split(",".into());
             file_scanner.set_thumbnail_dir(temp_dir());
-            file_scanner
-                .set_scan_dir("/home/ovenoboyo/Nextcloud/Sahil/Music/Music that heals".into());
+            let scan_dir = std::env::var("TEMP_MOOSYNC_MUSIC_DIR")
+                .ok()
+                .map(std::path::PathBuf::from)
+                .or_else(|| platform_dirs::UserDirs::new().map(|d| d.music_dir));
+            if let Some(scan_dir) = scan_dir {
+                file_scanner.set_scan_dir(scan_dir);
+            }
 
             let database = self.plugins.get::<Database>();
             file_scanner.set_on_playlist(move |p| {

--- a/external/ffmpeg/BUILD
+++ b/external/ffmpeg/BUILD
@@ -101,6 +101,8 @@ configure_make(
         "//:android_x86_64_config": ANDROID_FFMPEG_ANDROID_COMMON + ["--arch=x86_64"],
         "//:android_arm64_config": ANDROID_FFMPEG_ANDROID_COMMON + ["--arch=aarch64"],
         "//conditions:default": [
+            # Required so static archives can be linked into PIE executables (modern gcc default).
+            "--enable-pic",
             "--extra-libs=\"-lvorbis -lvorbisenc -lvorbisfile -logg -lm -lpthread\"",
         ],
     }),


### PR DESCRIPTION
## Summary by Sourcery

Make state manager music scan directory configurable and remove environment-specific project files.

Enhancements:
- Resolve the music scan directory dynamically from an environment variable or the user music directory instead of a hardcoded path.

Build:
- Remove Android local.properties from the repo to avoid committing environment-specific configuration.

Chores:
- Adjust editor configuration files under .vscode to clean up environment-specific settings.